### PR TITLE
CI: post messages to Slack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,11 @@ pipeline {
     agent { label 'general' }
     options {
         skipDefaultCheckout true
+        parallelsAlwaysFailFast()
     }
     environment {
         GO111MODULE = 'on'
+        SLACK_MESSAGE = "Data-Node CI » <${RUN_DISPLAY_URL}|Jenkins ${BRANCH_NAME} Job>${ env.CHANGE_URL ? " » <${CHANGE_URL}|GitHub PR #${CHANGE_ID}>" : '' }"
     }
 
     stages {
@@ -280,6 +282,18 @@ pipeline {
             steps {
                 echo 'Build version because this commit is tagged...'
                 echo 'and publish it'
+            }
+        }
+    }
+    post {
+        success {
+            retry(3) {
+                slackSend(channel: "#tradingcore-notify", color: "good", message: ":white_check_mark: ${SLACK_MESSAGE}")
+            }
+        }
+        failure {
+            retry(3) {
+                slackSend(channel: "#tradingcore-notify", color: "danger", message: ":red_circle: ${SLACK_MESSAGE}")
             }
         }
     }


### PR DESCRIPTION
Part of #4. Add posting messages to Slack upon Failed or Successful pipeline.
example: https://vegaprotocol.slack.com/archives/CH5LCQ1JP/p1627311936284000