### PR TITLE
Upload artifacts on release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,7 +228,7 @@ pipeline {
                             sh label: 'Log in to a Gihub with CI', script: '''
                                 echo ${TOKEN} | gh auth login --with-token -h github.com
                             '''
-                            sh label: 'Upload artifacts', script: '''
+                            sh label: 'Upload artifacts', script: '''#!/bin/bash -e
                                 [[ $TAG_NAME =~ '-pre' ]] && prerelease='--prerelease' || prerelease=''
                                 gh release create $TAG_NAME $prerelease ./cmd/data-node/data-node-*
                             '''


### PR DESCRIPTION
Part of #65.
Create a stage in Jenkinsfile that creates a new GitHub release and upload built artefacts. It must be triggered every time we create a version tag, e.g. `vX.Y.Z` or `vX.Y.Z-preN` (`X`, `Y`, `Z` and `N` are integers - can be more than one digit).