### PR TITLE
Enable CGO for unit tests with race flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,9 +226,9 @@ pipeline {
                 stage('unit tests') {
                     options { retry(3) }
                     steps {
-                        dir('vega') {
-                            sh 'go test -v ./... 2>&1 | tee unit-test-results.txt && cat unit-test-results.txt | go-junit-report > vega-unit-test-report.xml'
-                            junit checksName: 'Unit Tests', testResults: 'vega-unit-test-report.xml'
+                        dir('data-node') {
+                            sh 'go test -v ./... 2>&1 | tee unit-test-results.txt && cat unit-test-results.txt | go-junit-report > unit-test-report.xml'
+                            junit checksName: 'Unit Tests', testResults: 'unit-test-report.xml'
                         }
                     }
                 }
@@ -238,9 +238,9 @@ pipeline {
                     }
                     options { retry(3) }
                     steps {
-                        dir('vega') {
-                            sh 'go test -v -race ./... 2>&1 | tee unit-test-race-results.txt && cat unit-test-race-results.txt | go-junit-report > vega-unit-test-race-report.xml'
-                            junit checksName: 'Unit Tests with Race', testResults: 'vega-unit-test-race-report.xml'
+                        dir('data-node') {
+                            sh 'go test -v -race ./... 2>&1 | tee unit-test-race-results.txt && cat unit-test-race-results.txt | go-junit-report > unit-test-race-report.xml'
+                            junit checksName: 'Unit Tests with Race', testResults: 'unit-test-race-report.xml'
                         }
                     }
                 }


### PR DESCRIPTION
Closes #77.
Enable CGO for unit tests with race flag and remove publishing docker image for the main branch.