### PR TITLE
fix ID, PubKey and Status for Node

### DIFF
--- a/subscribers/validator_update.go
+++ b/subscribers/validator_update.go
@@ -65,12 +65,11 @@ func (vu *ValidatorUpdateSub) Push(evts ...events.Event) {
 			vue := et.Proto()
 
 			vu.nodeStore.AddNode(types.Node{
-				// @TODO - add Id
-				// Id: vue.GetInfoUrl(),
-				PubKey:   vue.GetTmPubKey(),
+				Id:       vue.GetTmPubKey(),
+				PubKey:   vue.GetVegaPubKey(),
 				InfoUrl:  vue.GetInfoUrl(),
 				Location: vue.GetCountry(),
-				Status:   types.NodeStatus_NODE_STATUS_NON_VALIDATOR,
+				Status:   types.NodeStatus_NODE_STATUS_VALIDATOR,
 			})
 		default:
 			vu.log.Panic("Unknown event type in candles subscriber", logging.String("Type", et.Type().String()))


### PR DESCRIPTION
As of now, in the core node id is the tendermint pubkey, also, we default all status to Validator, not NonValidator, and we se the PubKey to the vega pubkey.

close #111 