### PR TITLE
Update deps to fix withdrawal / deposits amounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module code.vegaprotocol.io/data-node
 go 1.16
 
 require (
-	code.vegaprotocol.io/protos v0.42.0
+	code.vegaprotocol.io/protos v0.42.1-0.20210913122716-3c9512012d8f
 	code.vegaprotocol.io/quant v0.2.5
-	code.vegaprotocol.io/vega v0.42.0
+	code.vegaprotocol.io/vega v0.42.1-0.20210913130643-9785e723bc85
 	github.com/99designs/gqlgen v0.13.0
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -13,12 +13,12 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 code.vegaprotocol.io/go-wallet v0.9.0-pre1.0.20210902202451-07b8234ec078/go.mod h1:Gfi5iMvEaRb58SdvWgzrnZEMwd2ftBhwdNdcEZw4XS0=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3/go.mod h1:1Gwg5D0PbFEE92Vip8EU0/+n80Kx3GwlGvP850S0op8=
 code.vegaprotocol.io/protos v0.42.0-pre6/go.mod h1:NORK22Evpwn0GoetL7H6/oVUzGcfjAJEJTzw+zTkSyE=
-code.vegaprotocol.io/protos v0.42.0 h1:RAu8rxfnbYn1oJ+UrLXNzIFavk+WJAtLEDEWdhHZ1N4=
-code.vegaprotocol.io/protos v0.42.0/go.mod h1:NORK22Evpwn0GoetL7H6/oVUzGcfjAJEJTzw+zTkSyE=
+code.vegaprotocol.io/protos v0.42.1-0.20210913122716-3c9512012d8f h1:vxb2F4+MCxzPJSKqQ8lm4DL6jOuP886nxFd68wVjxqk=
+code.vegaprotocol.io/protos v0.42.1-0.20210913122716-3c9512012d8f/go.mod h1:NORK22Evpwn0GoetL7H6/oVUzGcfjAJEJTzw+zTkSyE=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
-code.vegaprotocol.io/vega v0.42.0 h1:MQTG74O8GCXu/YBLSrQOWwWkRQiejAmdHwzr+amxxtU=
-code.vegaprotocol.io/vega v0.42.0/go.mod h1:gc5nG4kaSIannk/YkCOVgj0Gwbx9gEPOEaUmYl+FdDc=
+code.vegaprotocol.io/vega v0.42.1-0.20210913130643-9785e723bc85 h1:/tyA9+NrszPrePQ+UQ9NQmROUXekstyDx648OaVpDFk=
+code.vegaprotocol.io/vega v0.42.1-0.20210913130643-9785e723bc85/go.mod h1:xeCRoWR2gwEL2B0cFtTy3MPSahVOdjGnsU7oiwPZFx4=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 github.com/99designs/gqlgen v0.13.0 h1:haLTcUp3Vwp80xMVEg5KRNwzfUrgFdRmtBY8fuB8scA=


### PR DESCRIPTION
Update the vega + protos deps to use the last version of the withdraw and deposits.