### PR TITLE
chore: migrate timeseries to consistent format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🛠  Improvements
 - [386](https://github.com/vegaprotocol/data-node/pull/386) - Migrate withdrawal API to retrieve data from `Postgres`
 - [378](https://github.com/vegaprotocol/data-node/issues/378) - Migrate existing Oracles API to new `Postgres` database.
+- [461](https://github.com/vegaprotocol/data-node/pull/461) - Migrate market data time series to consistent format
 - [](https://github.com/vegaprotocol/data-node/pull/xxx) -
 
 ### 🐛 Fixes

--- a/entities/marketdata.go
+++ b/entities/marketdata.go
@@ -69,6 +69,8 @@ type MarketData struct {
 	MarketValueProxy string
 	// the equity like share of liquidity fee for each liquidity provider
 	LiquidityProviderFeeShares []*LiquidityProviderFeeShare
+	// A synthetic time created which is the sum of vega_time + (seq num * Microsecond)
+	SyntheticTime time.Time
 	// Vega Block time at which the data was received from Vega Node
 	VegaTime time.Time
 	// SeqNum is the order in which the market data was received in the block

--- a/sqlstore/migrations/0001_initial.sql
+++ b/sqlstore/migrations/0001_initial.sql
@@ -172,9 +172,10 @@ create type market_trading_mode_type as enum('TRADING_MODE_UNSPECIFIED', 'TRADIN
 create type market_state_type as enum('STATE_UNSPECIFIED', 'STATE_PROPOSED', 'STATE_REJECTED', 'STATE_PENDING', 'STATE_CANCELLED', 'STATE_ACTIVE', 'STATE_SUSPENDED', 'STATE_CLOSED', 'STATE_TRADING_TERMINATED', 'STATE_SETTLED');
 
 create table market_data (
-    market bytea not null,
+    synthetic_time       TIMESTAMP WITH TIME ZONE NOT NULL,
     vega_time timestamp with time zone not null references blocks(vega_time),
-    seq_num bigint not null,
+    seq_num    BIGINT NOT NULL,
+    market bytea not null,
     mark_price numeric(32),
     best_bid_price numeric(32),
     best_bid_volume bigint,
@@ -201,7 +202,7 @@ create table market_data (
     liquidity_provider_fee_shares jsonb
 );
 
-select create_hypertable('market_data', 'vega_time', chunk_time_interval => INTERVAL '1 day');
+select create_hypertable('market_data', 'synthetic_time', chunk_time_interval => INTERVAL '1 day');
 
 create index on market_data (market, vega_time);
 

--- a/sqlstore/trades.go
+++ b/sqlstore/trades.go
@@ -67,7 +67,7 @@ func (ts *Trades) OnTimeUpdateEvent(ctx context.Context) error {
 		}
 
 		if copyCount != int64(len(rows)) {
-			return fmt.Errorf("copied %d rows into the database, expected to copy %d", copyCount, len(rows))
+			return fmt.Errorf("copied %d trade rows into the database, expected to copy %d", copyCount, len(rows))
 		}
 	}
 

--- a/sqlsubscribers/mocks/market_data_mock.go
+++ b/sqlsubscribers/mocks/market_data_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	entities "code.vegaprotocol.io/data-node/entities"
@@ -46,4 +47,18 @@ func (m *MockMarketDataStore) Add(arg0 *entities.MarketData) error {
 func (mr *MockMarketDataStoreMockRecorder) Add(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockMarketDataStore)(nil).Add), arg0)
+}
+
+// OnTimeUpdateEvent mocks base method.
+func (m *MockMarketDataStore) OnTimeUpdateEvent(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OnTimeUpdateEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// OnTimeUpdateEvent indicates an expected call of OnTimeUpdateEvent.
+func (mr *MockMarketDataStoreMockRecorder) OnTimeUpdateEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnTimeUpdateEvent", reflect.TypeOf((*MockMarketDataStore)(nil).OnTimeUpdateEvent), arg0)
 }


### PR DESCRIPTION
closes #462 

To migrate the market data time series to match the pattern used for trades.  In addition the market data write is batched (also consistent with trades).  This allows continuous aggregates to be used on the data.  Rough testing shows the batching improves throughput by roughly an order of magnitude (2k per sec without versus 16k per sec with batching using event data from the full system test suite)