### PR TITLE
chore: refactor type() method on subscribers to types()

### DIFF
--- a/broker/sqlstore_broker_test.go
+++ b/broker/sqlstore_broker_test.go
@@ -106,8 +106,8 @@ func (t testSqlBrokerSubscriber) Push(evt events.Event) {
 	t.receivedCh <- evt
 }
 
-func (t testSqlBrokerSubscriber) Type() events.Type {
-	return t.eventType
+func (t testSqlBrokerSubscriber) Types() []events.Type {
+	return []events.Type{t.eventType}
 }
 
 type testChainInfo struct {

--- a/sqlsubscribers/asset.go
+++ b/sqlsubscribers/asset.go
@@ -36,8 +36,8 @@ func NewAsset(store AssetStore, log *logging.Logger) *Asset {
 	}
 }
 
-func (a *Asset) Type() events.Type {
-	return events.AssetEvent
+func (a *Asset) Types() []events.Type {
+	return []events.Type{events.AssetEvent}
 }
 
 func (as *Asset) Push(evt events.Event) {

--- a/sqlsubscribers/checkpoint.go
+++ b/sqlsubscribers/checkpoint.go
@@ -36,8 +36,8 @@ func NewCheckpoint(
 	return np
 }
 
-func (n *Checkpoint) Type() events.Type {
-	return events.CheckpointEvent
+func (n *Checkpoint) Types() []events.Type {
+	return []events.Type{events.CheckpointEvent}
 }
 
 func (n *Checkpoint) Push(evt events.Event) {

--- a/sqlsubscribers/delegations.go
+++ b/sqlsubscribers/delegations.go
@@ -36,8 +36,8 @@ func NewDelegation(
 	return t
 }
 
-func (ds *Delegation) Type() events.Type {
-	return events.DelegationBalanceEvent
+func (ds *Delegation) Types() []events.Type {
+	return []events.Type{events.DelegationBalanceEvent}
 }
 
 func (ds *Delegation) Push(evt events.Event) {

--- a/sqlsubscribers/deposits.go
+++ b/sqlsubscribers/deposits.go
@@ -32,8 +32,8 @@ func NewDeposit(store DepositStore, log *logging.Logger) *Deposit {
 	}
 }
 
-func (d *Deposit) Type() events.Type {
-	return events.DepositEvent
+func (d *Deposit) Types() []events.Type {
+	return []events.Type{events.DepositEvent}
 }
 
 func (d *Deposit) Push(evt events.Event) {

--- a/sqlsubscribers/epoch.go
+++ b/sqlsubscribers/epoch.go
@@ -36,8 +36,8 @@ func NewEpoch(
 	return t
 }
 
-func (es *Epoch) Type() events.Type {
-	return events.EpochUpdate
+func (es *Epoch) Types() []events.Type {
+	return []events.Type{events.EpochUpdate}
 }
 
 func (es *Epoch) Push(evt events.Event) {

--- a/sqlsubscribers/liquidity_provision.go
+++ b/sqlsubscribers/liquidity_provision.go
@@ -32,8 +32,8 @@ func NewLiquidityProvision(store LiquidityProvisionStore, log *logging.Logger) *
 	}
 }
 
-func (lp *LiquidityProvision) Type() events.Type {
-	return events.LiquidityProvisionEvent
+func (lp *LiquidityProvision) Types() []events.Type {
+	return []events.Type{events.LiquidityProvisionEvent}
 }
 
 func (lp *LiquidityProvision) Push(evt events.Event) {

--- a/sqlsubscribers/margin_levels.go
+++ b/sqlsubscribers/margin_levels.go
@@ -32,8 +32,8 @@ func NewMarginLevels(store MarginLevelsStore, log *logging.Logger) *MarginLevels
 	}
 }
 
-func (ml *MarginLevels) Type() events.Type {
-	return events.MarginLevelsEvent
+func (ml *MarginLevels) Types() []events.Type {
+	return []events.Type{events.MarginLevelsEvent}
 }
 
 func (ml *MarginLevels) Push(evt events.Event) {

--- a/sqlsubscribers/market_created.go
+++ b/sqlsubscribers/market_created.go
@@ -32,8 +32,8 @@ func NewMarketCreated(store MarketsStore, log *logging.Logger) *MarketCreated {
 	}
 }
 
-func (m *MarketCreated) Type() events.Type {
-	return events.MarketCreatedEvent
+func (m *MarketCreated) Types() []events.Type {
+	return []events.Type{events.MarketCreatedEvent}
 }
 
 func (m *MarketCreated) Push(evt events.Event) {

--- a/sqlsubscribers/market_data.go
+++ b/sqlsubscribers/market_data.go
@@ -43,8 +43,8 @@ func (md *MarketData) Push(evt events.Event) {
 	}
 }
 
-func (md *MarketData) Type() events.Type {
-	return events.MarketDataEvent
+func (md *MarketData) Types() []events.Type {
+	return []events.Type{events.MarketDataEvent}
 }
 
 func NewMarketData(store MarketDataStore, log *logging.Logger, dbTimeout time.Duration) *MarketData {

--- a/sqlsubscribers/market_updated.go
+++ b/sqlsubscribers/market_updated.go
@@ -27,8 +27,8 @@ func NewMarketUpdated(store MarketsStore, log *logging.Logger) *MarketUpdated {
 	}
 }
 
-func (m *MarketUpdated) Type() events.Type {
-	return events.MarketUpdatedEvent
+func (m *MarketUpdated) Types() []events.Type {
+	return []events.Type{events.MarketUpdatedEvent}
 }
 
 func (m *MarketUpdated) Push(evt events.Event) {

--- a/sqlsubscribers/network_limits.go
+++ b/sqlsubscribers/network_limits.go
@@ -37,8 +37,8 @@ func NewNetworkLimitSub(
 	return t
 }
 
-func (t *NetworkLimits) Type() events.Type {
-	return events.NetworkLimitsEvent
+func (t *NetworkLimits) Types() []events.Type {
+	return []events.Type{events.NetworkLimitsEvent}
 }
 
 func (nl *NetworkLimits) Push(evt events.Event) {

--- a/sqlsubscribers/network_parameters.go
+++ b/sqlsubscribers/network_parameters.go
@@ -36,8 +36,8 @@ func NewNetworkParameter(
 	return np
 }
 
-func (n *NetworkParameter) Type() events.Type {
-	return events.NetworkParameterEvent
+func (n *NetworkParameter) Types() []events.Type {
+	return []events.Type{events.NetworkParameterEvent}
 }
 
 func (n *NetworkParameter) Push(evt events.Event) {

--- a/sqlsubscribers/oracle_data.go
+++ b/sqlsubscribers/oracle_data.go
@@ -32,8 +32,8 @@ func NewOracleData(store OracleDataStore, log *logging.Logger) *OracleData {
 	}
 }
 
-func (od *OracleData) Type() events.Type {
-	return events.OracleDataEvent
+func (od *OracleData) Types() []events.Type {
+	return []events.Type{events.OracleDataEvent}
 }
 
 func (od *OracleData) Push(evt events.Event) {

--- a/sqlsubscribers/oracle_spec.go
+++ b/sqlsubscribers/oracle_spec.go
@@ -32,8 +32,8 @@ func NewOracleSpec(store OracleSpecStore, log *logging.Logger) *OracleSpec {
 	}
 }
 
-func (od *OracleSpec) Type() events.Type {
-	return events.OracleSpecEvent
+func (od *OracleSpec) Types() []events.Type {
+	return []events.Type{events.OracleSpecEvent}
 }
 
 func (od *OracleSpec) Push(evt events.Event) {

--- a/sqlsubscribers/order.go
+++ b/sqlsubscribers/order.go
@@ -32,8 +32,8 @@ func NewOrder(ctx context.Context, store OrderStore, blockStore BlockStore, log 
 	}
 }
 
-func (os *Order) Type() events.Type {
-	return events.OrderEvent
+func (os *Order) Types() []events.Type {
+	return []events.Type{events.OrderEvent}
 }
 
 func (os *Order) Push(evt events.Event) {

--- a/sqlsubscribers/party.go
+++ b/sqlsubscribers/party.go
@@ -36,8 +36,8 @@ func NewParty(
 	return ps
 }
 
-func (ps *Party) Type() events.Type {
-	return events.PartyEvent
+func (ps *Party) Types() []events.Type {
+	return []events.Type{events.PartyEvent}
 }
 
 func (ps *Party) Push(evt events.Event) {

--- a/sqlsubscribers/proposal.go
+++ b/sqlsubscribers/proposal.go
@@ -38,8 +38,8 @@ func NewProposal(
 	return ps
 }
 
-func (ps *Proposal) Type() events.Type {
-	return events.ProposalEvent
+func (ps *Proposal) Types() []events.Type {
+	return []events.Type{events.ProposalEvent}
 }
 
 func (rs *Proposal) Push(evt events.Event) {

--- a/sqlsubscribers/rewards.go
+++ b/sqlsubscribers/rewards.go
@@ -36,8 +36,8 @@ func NewReward(
 	return t
 }
 
-func (rs *Reward) Type() events.Type {
-	return events.RewardPayoutEvent
+func (rs *Reward) Types() []events.Type {
+	return []events.Type{events.RewardPayoutEvent}
 }
 
 func (rs *Reward) Push(evt events.Event) {

--- a/sqlsubscribers/risk_factors.go
+++ b/sqlsubscribers/risk_factors.go
@@ -32,8 +32,8 @@ func NewRiskFactor(store RiskFactorStore, log *logging.Logger) *RiskFactor {
 	}
 }
 
-func (rf *RiskFactor) Type() events.Type {
-	return events.RiskFactorEvent
+func (rf *RiskFactor) Types() []events.Type {
+	return []events.Type{events.RiskFactorEvent}
 }
 
 func (rf *RiskFactor) Push(evt events.Event) {

--- a/sqlsubscribers/time_update.go
+++ b/sqlsubscribers/time_update.go
@@ -35,8 +35,8 @@ func NewTimeSub(
 	return t
 }
 
-func (t *Time) Type() events.Type {
-	return events.TimeUpdate
+func (t *Time) Types() []events.Type {
+	return []events.Type{events.TimeUpdate}
 }
 
 func (t *Time) Push(evt events.Event) {

--- a/sqlsubscribers/trades.go
+++ b/sqlsubscribers/trades.go
@@ -35,8 +35,8 @@ func NewTradesSubscriber(store TradesStore, log *logging.Logger) *TradeSubscribe
 	}
 }
 
-func (ts *TradeSubscriber) Type() events.Type {
-	return events.TradeEvent
+func (ts *TradeSubscriber) Types() []events.Type {
+	return []events.Type{events.TradeEvent}
 }
 
 func (ts *TradeSubscriber) Push(evt events.Event) {

--- a/sqlsubscribers/transfer_response.go
+++ b/sqlsubscribers/transfer_response.go
@@ -53,8 +53,8 @@ func NewTransferResponse(
 	}
 }
 
-func (t *TransferResponse) Type() events.Type {
-	return events.TransferResponses
+func (t *TransferResponse) Types() []events.Type {
+	return []events.Type{events.TransferResponses}
 }
 
 func (t *TransferResponse) Push(evt events.Event) {

--- a/sqlsubscribers/vote.go
+++ b/sqlsubscribers/vote.go
@@ -39,8 +39,8 @@ func NewVote(
 	return vs
 }
 
-func (vs *Vote) Type() events.Type {
-	return events.VoteEvent
+func (vs *Vote) Types() []events.Type {
+	return []events.Type{events.VoteEvent}
 }
 
 func (vs *Vote) Push(evt events.Event) {

--- a/sqlsubscribers/withdrawals.go
+++ b/sqlsubscribers/withdrawals.go
@@ -32,8 +32,8 @@ func NewWithdrawal(store WithdrawalStore, log *logging.Logger) *Withdrawal {
 	}
 }
 
-func (w *Withdrawal) Type() events.Type {
-	return events.WithdrawalEvent
+func (w *Withdrawal) Types() []events.Type {
+	return []events.Type{events.WithdrawalEvent}
 }
 
 func (w *Withdrawal) Push(evt events.Event) {


### PR DESCRIPTION
I bumped into a subscriber (positions) that really does want more than one event type, so refactor the broker/sqlsubscriber to use `Types()` instead of `Type()`