### PR TITLE
Add event handling metrics

### DIFF
--- a/broker/sqlstore_broker_test.go
+++ b/broker/sqlstore_broker_test.go
@@ -26,7 +26,7 @@ func testSqlBrokerEventDistribution(t *testing.T, sequential bool) {
 	s1 := testSqlBrokerSubscriber{eventType: events.AssetEvent, receivedCh: make(chan events.Event)}
 	s2 := testSqlBrokerSubscriber{eventType: events.AssetEvent, receivedCh: make(chan events.Event)}
 	s3 := testSqlBrokerSubscriber{eventType: events.AccountEvent, receivedCh: make(chan events.Event)}
-	tes, sb := createTestBroker(t, sequential, s1, s2, s3)
+	tes, sb := createTestBroker(t, sequential, &s1, &s2, &s3)
 	go sb.Receive(context.Background())
 
 	tes.eventsCh <- events.NewAssetEvent(context.Background(), types.Asset{ID: "a1"})
@@ -52,7 +52,7 @@ func TestSqlBrokerTimeEventSentToAllSubscribers(t *testing.T) {
 func testSqlBrokerTimeEventSentToAllSubscribers(t *testing.T, sequential bool) {
 	s1 := testSqlBrokerSubscriber{eventType: events.AssetEvent, receivedCh: make(chan events.Event)}
 	s2 := testSqlBrokerSubscriber{eventType: events.AssetEvent, receivedCh: make(chan events.Event)}
-	tes, sb := createTestBroker(t, sequential, s1, s2)
+	tes, sb := createTestBroker(t, sequential, &s1, &s2)
 
 	go sb.Receive(context.Background())
 
@@ -71,7 +71,7 @@ func TestSqlBrokerTimeEventOnlySendOnceToTimeSubscribers(t *testing.T) {
 
 func testNewSqlStoreBrokerestSqlBrokerTimeEventOnlySendOnceToTimeSubscribers(t *testing.T, seq bool) {
 	s1 := testSqlBrokerSubscriber{eventType: events.TimeUpdate, receivedCh: make(chan events.Event)}
-	tes, sb := createTestBroker(t, seq, s1)
+	tes, sb := createTestBroker(t, seq, &s1)
 
 	go sb.Receive(context.Background())
 

--- a/entities/id.go
+++ b/entities/id.go
@@ -17,6 +17,11 @@ var wellKnownIds = map[string]string{
 	systemOwnerStr: "01",
 	noMarketStr:    "02",
 	"network":      "03",
+	"XYZalpha":     "04",
+	"XYZbeta":      "05",
+	"XYZdelta":     "06",
+	"XYZepsilon":   "07",
+	"XYZgamma":     "08",
 }
 
 var wellKnownIdsReversed = map[string]string{
@@ -24,6 +29,11 @@ var wellKnownIdsReversed = map[string]string{
 	"01": systemOwnerStr,
 	"02": noMarketStr,
 	"03": "network",
+	"04": "XYZalpha",
+	"05": "XYZbeta",
+	"06": "XYZdelta",
+	"07": "XYZepsilon",
+	"08": "XYZgamma",
 }
 
 func (id *ID) Bytes() ([]byte, error) {

--- a/metrics/timecounter.go
+++ b/metrics/timecounter.go
@@ -35,3 +35,11 @@ func (tc *TimeCounter) EngineTimeCounterAdd() {
 	}
 	engineTime.WithLabelValues(tc.labelValues...).Add(time.Since(tc.start).Seconds())
 }
+
+func (tc *TimeCounter) EventTimeCounterAdd() {
+	// Check that the metric has been set up. (Testing does not use metrics.)
+	if eventHandlingTime == nil {
+		return
+	}
+	eventHandlingTime.WithLabelValues(tc.labelValues...).Add(time.Since(tc.start).Seconds())
+}


### PR DESCRIPTION
Add a couple of extra counters to our Prometheus metrics so we can track how much time is spent handling each event type.