### PR TITLE
fix: collect all validator update events for a block before flushing …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Fixes
 - [524](https://github.com/vegaprotocol/data-node/issues/524) - Fix for incorrect balances
+- [520](https://github.com/vegaprotocol/data-node/issues/520) - Fix event race where a ranking event can come in before the new node event
 - [519](https://github.com/vegaprotocol/data-node/issues/519) - Fix market depth update subscriptions streaming events for all markets.
 - [](https://github.com/vegaprotocol/data-node/issues/xxx) -
 

--- a/api_test/testutil_test.go
+++ b/api_test/testutil_test.go
@@ -167,6 +167,7 @@ func NewTestServer(t testing.TB, ctx context.Context, blocking bool) *TestServer
 	nodesSub := subscribers.NewNodesSub(ctx, nodeStore, logger, true)
 
 	epochStore := storage.NewEpoch(logger, nodeStore, conf.Storage)
+	epochSub := subscribers.NewEpochUpdateSub(ctx, epochStore, logger, true)
 	delegationBalanceSub := subscribers.NewDelegationBalanceSub(ctx, nodeStore, epochStore, delegationStore, logger, true)
 
 	tradeService := trades.NewService(logger, conf.Trades, tradeStore, nil)
@@ -274,6 +275,7 @@ func NewTestServer(t testing.TB, ctx context.Context, blocking bool) *TestServer
 		delegationBalanceSub,
 		rewardsService,
 		nodesSub,
+		epochSub,
 	)
 
 	srv := api.NewGRPCServer(

--- a/storage/nodes.go
+++ b/storage/nodes.go
@@ -11,7 +11,10 @@ import (
 	"code.vegaprotocol.io/protos/vega"
 	pb "code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/types/num"
+	"github.com/pkg/errors"
 )
+
+var ErrNodeDoesNotExist = errors.New("node does not exist")
 
 type node struct {
 	n pb.Node
@@ -93,17 +96,18 @@ func (ns *Node) AddNodeRewardScore(nodeID, epochID string, scoreData vega.Reward
 	node.rewardScoresPerEpoch[epochID] = scoreData
 }
 
-func (ns *Node) AddNodeRankingScore(nodeID, epochID string, scoreData vega.RankingScore) {
+func (ns *Node) AddNodeRankingScore(nodeID, epochID string, rankingData vega.RankingScore) error {
 	ns.mut.Lock()
 	defer ns.mut.Unlock()
 
 	node, ok := ns.nodes[nodeID]
 	if !ok {
 		ns.log.Error("Received node ranking for non existing node", logging.String("node_id", nodeID))
-		return
+		return ErrNodeDoesNotExist
 	}
 
-	node.rankingPerEpoch[epochID] = scoreData
+	node.rankingPerEpoch[epochID] = rankingData
+	return nil
 }
 
 func (ns *Node) AddDelegation(de pb.Delegation) {


### PR DESCRIPTION
closes #520 

I know this is in the old non-postgres code path, but it was causing me pain in my validator-joining-and-leaving testing. Whenever the nodes stuff is migrated to the V2 we'll need to make sure a similar fix is included!