### PR TITLE
Data retention live orders table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [495](https://github.com/vegaprotocol/data-node/pull/495) - Remove deprecated `PositionState` event handling, general fixes to `SettlePosition` event handling
 - [498](https://github.com/vegaprotocol/data-node/issues/498) - Transaction event broker
 - [521](https://github.com/vegaprotocol/data-node/issues/521) - Refactor margin levels to use account id 
+- [533](https://github.com/vegaprotocol/data-node/issues/533) - Order data retention 
 
 - [](https://github.com/vegaprotocol/data-node/pull/xxx) -
 

--- a/api_test/testutil_test.go
+++ b/api_test/testutil_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/data-node/candlesv2"
-
 	vgtesting "code.vegaprotocol.io/data-node/libs/testing"
 	"code.vegaprotocol.io/data-node/sqlstore"
 	"github.com/golang/protobuf/jsonpb"
@@ -211,6 +210,7 @@ func NewTestServer(t testing.TB, ctx context.Context, blocking bool) *TestServer
 	}
 
 	sqlStore := sqlstore.ConnectionSource{}
+
 	sqlBalanceStore := sqlstore.NewBalances(&sqlStore)
 	sqlMarketDataStore := sqlstore.NewMarketData(&sqlStore)
 

--- a/entities/order.go
+++ b/entities/order.go
@@ -164,6 +164,14 @@ func (o Order) ToRow() []interface{} {
 	}
 }
 
+func (o Order) IsLive() bool {
+	if o.TimeInForce == OrderTimeInForceIOC || o.TimeInForce == OrderTimeInForceFOK {
+		return false
+	}
+
+	return o.Status == OrderStatusActive || o.Status == OrderStatusPartiallyFilled
+}
+
 var OrderColumns = []string{
 	"id", "market_id", "party_id", "side", "price",
 	"size", "remaining", "time_in_force", "type", "status",

--- a/sqlstore/config.go
+++ b/sqlstore/config.go
@@ -53,7 +53,7 @@ func NewDefaultConfig() Config {
 			Username:        "vega",
 			Password:        "vega",
 			Database:        "vega",
-			UseTransactions: true,
+			UseTransactions: false,
 		},
 		WipeOnStartup:    true,
 		Level:            encoding.LogLevel{Level: logging.InfoLevel},


### PR DESCRIPTION
closes #533    This change adds a live orders table which allows us to delete from order history without removing live orders and as such allows for an arbitrary length retention policy on order history data.

perf tests on the change before/after and in summary it makes no difference, here's comparison for first 50K blocks of testnet data: https://docs.google.com/spreadsheets/d/1s0Fwrje28J7ESlJ_9sR3MVH8hfbDB5Pm2U8ogzJOQkg/edit?usp=sharing ,  

Also I added an index for the id column to the orders (now order_history) table and ran a perf test just in case, impact was neglible: https://docs.google.com/spreadsheets/d/1SBlJ_WfcJYn_GkgH8XQEBKpVKyuS2E44vmE46GMhhhU/edit?usp=sharing


