### PR TITLE
chore: remove FK constraints from hypertables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [553](https://github.com/vegaprotocol/data-node/issues/553) - Update transfers API to expose dispatch strategy
 - [578](https://github.com/vegaprotocol/data-node/issues/578) - Add metrics for `SQL` queries
 - [582](https://github.com/vegaprotocol/data-node/issues/582) - Add a cache for assets
+- [548](https://github.com/vegaprotocol/data-node/issues/548) - Remove foreign key constraints on hyper tables 
 
 ### 🐛 Fixes
 - [524](https://github.com/vegaprotocol/data-node/issues/524) - Fix for incorrect balances

--- a/sqlstore/migrations/0001_initial.sql
+++ b/sqlstore/migrations/0001_initial.sql
@@ -51,10 +51,10 @@ create table balances
 create table ledger
 (
     id              SERIAL                   ,--PRIMARY KEY,
-    account_from_id INT                      NOT NULL REFERENCES accounts(id),
-    account_to_id   INT                      NOT NULL REFERENCES accounts(id),
+    account_from_id INT                      NOT NULL,
+    account_to_id   INT                      NOT NULL,
     quantity        NUMERIC(32, 0)           NOT NULL,
-    vega_time       TIMESTAMP WITH TIME ZONE NOT NULL REFERENCES blocks(vega_time),
+    vega_time       TIMESTAMP WITH TIME ZONE NOT NULL,
     transfer_time   TIMESTAMP WITH TIME ZONE NOT NULL,
     reference       TEXT,
     type            TEXT
@@ -84,7 +84,7 @@ CREATE TABLE orders (
     created_at        TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at        TIMESTAMP WITH TIME ZONE,
     expires_at        TIMESTAMP WITH TIME ZONE,
-    vega_time         TIMESTAMP WITH TIME ZONE NOT NULL REFERENCES blocks(vega_time),
+    vega_time         TIMESTAMP WITH TIME ZONE NOT NULL,
     seq_num           BIGINT NOT NULL -- event sequence number in the block
     -- PRIMARY key(vega_time, id, version)
 );
@@ -110,7 +110,7 @@ CREATE VIEW orders_current_versions AS (
 create table trades
 (
     synthetic_time       TIMESTAMP WITH TIME ZONE NOT NULL,
-    vega_time       TIMESTAMP WITH TIME ZONE NOT NULL REFERENCES blocks(vega_time),
+    vega_time       TIMESTAMP WITH TIME ZONE NOT NULL,
     seq_num    BIGINT NOT NULL,
     id     BYTEA NOT NULL,
     market_id BYTEA NOT NULL,
@@ -287,7 +287,7 @@ create type market_state_type as enum('STATE_UNSPECIFIED', 'STATE_PROPOSED', 'ST
 
 create table market_data (
     synthetic_time       TIMESTAMP WITH TIME ZONE NOT NULL,
-    vega_time timestamp with time zone not null references blocks(vega_time),
+    vega_time timestamp with time zone not null,
     seq_num    BIGINT NOT NULL,
     market bytea not null,
     mark_price numeric(32),
@@ -461,7 +461,7 @@ create table if not exists margin_levels (
     search_level numeric(32, 0),
     initial_margin numeric(32, 0),
     collateral_release_level numeric(32, 0),
-    vega_time timestamp with time zone not null references blocks(vega_time)
+    vega_time timestamp with time zone not null
 );
 
 select create_hypertable('margin_levels', 'vega_time', chunk_time_interval => INTERVAL '1 day');

--- a/sqlstore/sqlstore_test.go
+++ b/sqlstore/sqlstore_test.go
@@ -29,7 +29,8 @@ var (
 	maxPort               = 40000
 	testDBPort       int
 
-	tableNames            = [...]string{"ledger", "accounts", "parties", "assets", "blocks", "node_signatures", "erc20_multisig_signer_events"}
+	tableNames = [...]string{"ledger", "accounts", "parties", "assets", "blocks", "node_signatures",
+		"erc20_multisig_signer_events", "trades", "market_data", "orders"}
 	postgresServerTimeout = time.Second * 10
 )
 


### PR DESCRIPTION
closes #548.  We have seen a number of cases where enforcing the foreign key contraints on a hyper table on new chunk creation is causing a time out, before and after removal of foreign key contraints can be seen here: https://docs.google.com/spreadsheets/d/1-6uKNvF2dMFOeNXSX1syXL61dDngcp12Tc9kxniJf8E/edit?usp=sharing