### PR TITLE
fix: convert marketid into bytes when doing balance query

### DIFF
--- a/sqlstore/accounts_filter.go
+++ b/sqlstore/accounts_filter.go
@@ -84,9 +84,13 @@ func filterAccountBalancesQuery(af entities.AccountFilter, pagination entities.P
 	}
 
 	if len(af.Markets) > 0 {
-		marketIDs := make([]entities.MarketID, len(af.Markets))
+		marketIDs := make([][]byte, len(af.Markets))
 		for i, market := range af.Markets {
-			marketIDs[i] = market.ID
+			bytes, err := market.ID.Bytes()
+			if err != nil {
+				return "", nil, fmt.Errorf("Couldn't decode market ID: %w", err)
+			}
+			marketIDs[i] = bytes
 		}
 
 		where = fmt.Sprintf(`%s%sACCOUNTS.market_id=ANY(%s)`, where, and, nextBindVar(&args, marketIDs))

--- a/sqlstore/accounts_test.go
+++ b/sqlstore/accounts_test.go
@@ -86,4 +86,9 @@ func TestAccount(t *testing.T) {
 	accs, err = accountStore.Query(filter)
 	require.NoError(t, err)
 	assert.Len(t, accs, 0)
+
+	// QueryBalance correctly filters on marketID
+	filter = entities.AccountFilter{Asset: asset, Markets: []entities.Market{{ID: entities.NewMarketID(account.MarketID.String())}}}
+	_, err = accountStore.QueryBalances(context.Background(), filter, entities.Pagination{})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This fixes the `test_fees_amend_price` system-test which is annoyingly not related to the data-node panic.