### PR TITLE
chore: fix race condition cause by protobuf copying in v1 store

### DIFF
--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -197,7 +197,7 @@ type EventService interface {
 // LiquidityService ...
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/liquidity_service_mock.go -package mocks code.vegaprotocol.io/data-node/api LiquidityService
 type LiquidityService interface {
-	Get(party, market string) ([]pbtypes.LiquidityProvision, error)
+	Get(party, market string) ([]*pbtypes.LiquidityProvision, error)
 }
 
 // NodeService ...
@@ -489,7 +489,7 @@ func (t *tradingDataService) LiquidityProvisions(ctx context.Context, req *proto
 	out := make([]*pbtypes.LiquidityProvision, 0, len(lps))
 	for _, v := range lps {
 		v := v
-		out = append(out, &v)
+		out = append(out, v)
 	}
 	return &protoapi.LiquidityProvisionsResponse{
 		LiquidityProvisions: out,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module code.vegaprotocol.io/data-node
 go 1.18
 
 require (
-	code.vegaprotocol.io/protos v0.51.1-0.20220516093119-2a7ded6bc6ac
+	code.vegaprotocol.io/protos v0.51.1-0.20220516133726-24cd97cdeea0
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20220321185018-3b5684b00533
 	code.vegaprotocol.io/vega v0.51.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ code.vegaprotocol.io/protos v0.51.0 h1:HscwExZenysYze9N43JTqR1mStpUB82Hb48oY+lHX
 code.vegaprotocol.io/protos v0.51.0/go.mod h1:4BqwDw6jhc/mnwbXq8ZFUtYBFCnk8tBW6zuPsBt8OrQ=
 code.vegaprotocol.io/protos v0.51.1-0.20220516093119-2a7ded6bc6ac h1:C9q+9iZi0PAWPkY+2D7qYVIbJzaTeF4+vQlSFNEwfIc=
 code.vegaprotocol.io/protos v0.51.1-0.20220516093119-2a7ded6bc6ac/go.mod h1:4BqwDw6jhc/mnwbXq8ZFUtYBFCnk8tBW6zuPsBt8OrQ=
+code.vegaprotocol.io/protos v0.51.1-0.20220516133726-24cd97cdeea0 h1:aKlt/Dvs625BVyirb6tIydFL+93ZgqfDNsyCxKAmY1g=
+code.vegaprotocol.io/protos v0.51.1-0.20220516133726-24cd97cdeea0/go.mod h1:4BqwDw6jhc/mnwbXq8ZFUtYBFCnk8tBW6zuPsBt8OrQ=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20220321185018-3b5684b00533 h1:IxTWvyF0i0AgUAS+FTgQKIpbsS6Ki/Y9Ug0GSlgChJw=

--- a/sqlsubscribers/event_deduplicator.go
+++ b/sqlsubscribers/event_deduplicator.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 )
 
 // Used to get the set of events that have changed between flushes.  If an event is the same when flushed as it was
@@ -25,6 +25,7 @@ func NewEventDeduplicator[K comparable, V proto.Message](getId func(context.Cont
 }
 
 func (e *eventDeduplicator[K, V]) AddEvent(ctx context.Context, event V, vegaTime time.Time) error {
+
 	id, err := e.getId(ctx, event, vegaTime)
 	if err != nil {
 		return errors.Wrap(err, "failed to add event to deduplicator")


### PR DESCRIPTION
closes #607 Running integration tests with race flag was failing for liquidity provisions.  The event deduplicator uses the proto.Equals method, in combination with copying of proto messages in the v1 store this was causing a race condition fail on the integration tests.  The v1 store has been updated to use message pointers.