### PR TITLE
Datanode buffer configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,14 @@
 - [590](https://github.com/vegaprotocol/data-node/pull/590) - Implement pagination for `Data-Node V2 APIs` for Trades, Parties and Markets
 - [560](https://github.com/vegaprotocol/data-node/issues/560) - Implement pagination for `Data-Node V2 APIs` for Orders
 - [562](https://github.com/vegaprotocol/data-node/issues/560) - Implement pagination for `Data-Node V2 APIs` for Margin Levels
+- [625](https://github.com/vegaprotocol/data-node/issues/625) - Make socket server buffer size configurable
 - [630](https://github.com/vegaprotocol/data-node/issues/630) - Data retention across all historical data tables
 - [427](https://github.com/vegaprotocol/data-node/issues/427) - Handle recovery from snapshots 
 
 ### 🐛 Fixes
 - [616](https://github.com/vegaprotocol/data-node/pull/616) - Don't return multiple delegations per epoch/party/node
 - [627](https://github.com/vegaprotocol/data-node/issues/627) - User `from_epoch` in update event to determine if node exists
+- [](https://github.com/vegaprotocol/data-node/issues/xxx) -
 
 ## 0.51.0
 

--- a/broker/config.go
+++ b/broker/config.go
@@ -11,12 +11,14 @@ const namedLogger = "broker"
 
 // Config represents the configuration of the broker.
 type Config struct {
-	Level                  encoding.LogLevel     `long:"log-level"`
-	SocketConfig           SocketConfig          `group:"Socket" namespace:"socket"`
-	FileEventSourceConfig  FileEventSourceConfig `group:"FileEventSourceConfig" namespace:"fileeventsource"`
-	UseEventFile           encoding.Bool         `long:"use-event-file" description:"set to true to source events from a file"`
-	PanicOnError           encoding.Bool         `long:"panic-on-error" description:"if an error occurs on event push the broker will panic, else log the error"`
-	BlockProcessingTimeout encoding.Duration     `long:"block-processing-timeout" description:"The maximum time permitted for a block of events to be processed"`
+	Level                          encoding.LogLevel     `long:"log-level"`
+	SocketConfig                   SocketConfig          `group:"Socket" namespace:"socket"`
+	SocketServerInboundBufferSize  int                   `long:"socket-server-inbound-buffer-size"`
+	SocketServerOutboundBufferSize int                   `long:"socket-server-outbound-buffer-size"`
+	FileEventSourceConfig          FileEventSourceConfig `group:"FileEventSourceConfig" namespace:"fileeventsource"`
+	UseEventFile                   encoding.Bool         `long:"use-event-file" description:"set to true to source events from a file"`
+	PanicOnError                   encoding.Bool         `long:"panic-on-error" description:"if an error occurs on event push the broker will panic, else log the error"`
+	BlockProcessingTimeout         encoding.Duration     `long:"block-processing-timeout" description:"The maximum time permitted for a block of events to be processed"`
 }
 
 // NewDefaultConfig creates an instance of config with default values.
@@ -29,6 +31,8 @@ func NewDefaultConfig() Config {
 			MaxReceiveTimeouts: 3,
 			TransportType:      "tcp",
 		},
+		SocketServerInboundBufferSize:  10000,
+		SocketServerOutboundBufferSize: 10000,
 		FileEventSourceConfig: FileEventSourceConfig{
 			File:                  "vega.evt",
 			TimeBetweenBlocks:     encoding.Duration{Duration: 1 * time.Second},

--- a/broker/event_source.go
+++ b/broker/event_source.go
@@ -26,7 +26,7 @@ func NewEventSource(config Config, log *logging.Logger) (eventSource, error) {
 		}
 
 	} else {
-		eventsource, err = newSocketServer(log, &config.SocketConfig)
+		eventsource, err = newSocketServer(log, &config)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialise underlying socket receiver: %w", err)
 		}


### PR DESCRIPTION
close #625 PR to make the inbound/outbound channel buffer sizes of the socket server configurable.  From analysis of the core socket code and the databound socket code I am not convinced this will make the datanode any more resilient to disconnect, but good to have the option.