### PR TITLE
fix: remove extra 0x from multisig eth addresses, we don't need two

### DIFF
--- a/api/trading_data_v2.go
+++ b/api/trading_data_v2.go
@@ -397,8 +397,8 @@ func (t *tradingDataServiceV2) GetERC20MultiSigSignerAddedBundles(ctx context.Co
 
 		bundles = append(bundles,
 			&v2.ERC20MultiSigSignerAddedBundle{
-				NewSigner:  "0x" + b.SignerChange.String(),
-				Submitter:  "0x" + b.Submitter.String(),
+				NewSigner:  b.SignerChange.String(),
+				Submitter:  b.Submitter.String(),
 				Nonce:      b.Nonce,
 				Timestamp:  b.VegaTime.UnixNano(),
 				Signatures: pack,
@@ -471,8 +471,8 @@ func (t *tradingDataServiceV2) GetERC20MultiSigSignerRemovedBundles(ctx context.
 		}
 
 		bundles = append(bundles, &v2.ERC20MultiSigSignerRemovedBundle{
-			OldSigner:  "0x" + b.SignerChange.String(),
-			Submitter:  "0x" + b.Submitter.String(),
+			OldSigner:  b.SignerChange.String(),
+			Submitter:  b.Submitter.String(),
 			Nonce:      b.Nonce,
 			Timestamp:  b.VegaTime.UnixNano(),
 			Signatures: pack,

--- a/entities/utils.go
+++ b/entities/utils.go
@@ -86,7 +86,7 @@ type EthereumAddress string
 func (addr *EthereumAddress) Bytes() ([]byte, error) {
 	strAddr := addr.String()
 
-	if strings.HasPrefix(strAddr, "0x") == false {
+	if !strings.HasPrefix(strAddr, "0x") {
 		return nil, fmt.Errorf("invalid '%v': %w", string(addr.String()), ErrInvalidID)
 	}
 


### PR DESCRIPTION
We were returning the submitter/signer ethereum addresses prefixed with `0x0x`. 

Flexing this change in this test: https://github.com/vegaprotocol/system-tests/compare/0069-VCBS-001-validator-joins