### PR TITLE
fix: remove pk constraint for checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - [657](https://github.com/vegaprotocol/data-node/issues/657) - Add missing creation field in `ERC20` withdrawal bundle
 - [668](https://github.com/vegaprotocol/data-node/issues/668) - Ensure entity wrappers always hold timestamps to microsecond resolution 
 - [662](https://github.com/vegaprotocol/data-node/issues/662) - Fix auction trigger enum lookup
+- [682](https://github.com/vegaprotocol/data-node/issues/682) - Allow multiple checkpoints per block
+
 
 ## 0.51.1
 

--- a/sqlstore/migrations/0001_initial.sql
+++ b/sqlstore/migrations/0001_initial.sql
@@ -735,8 +735,7 @@ CREATE TABLE checkpoints(
     hash         TEXT                     NOT NULL,
     block_hash   TEXT                     NOT NULL,
     block_height BIGINT                   NOT NULL,
-    vega_time    TIMESTAMP WITH TIME ZONE NOT NULL REFERENCES blocks(vega_time),
-    PRIMARY KEY (block_height)
+    vega_time    TIMESTAMP WITH TIME ZONE NOT NULL REFERENCES blocks(vega_time)
 );
 
 CREATE TABLE positions(


### PR DESCRIPTION
Closes vegaprotocol/data-node#682 and vegaprotocol/vega#5700 

@wwestgarth [says on slack](https://vegaprotocol.slack.com/archives/C9E6XA8GK/p1655207343061189):

it is possible to get two checkpoints for the same block. We take a checkpoint at a set interval, but also we take them when a withdrawal happens. If a withdraw happens to happen on the same block we would naturally take a checkpoint we’ll get two checkpoint events for the same block 

It might be that core can _not_ do this, but while it does, don't force checkpoints to be unique on block height.