### PR TITLE
fix: market depth incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [569](https://github.com/vegaprotocol/data-node/issues/569) - Add cursor based pagination for withdrawal requests
 
 ### 🐛 Fixes
-- [](https://github.com/vegaprotocol/data-node/issues/xxx) -
+- [705](https://github.com/vegaprotocol/data-node/issues/705) - Market Depth returning incorrect book state
 
 ## 0.52.0
 

--- a/subscribers/order_events.go
+++ b/subscribers/order_events.go
@@ -3,6 +3,7 @@ package subscribers
 import (
 	"context"
 	"sync"
+	"time"
 
 	"code.vegaprotocol.io/data-node/logging"
 	types "code.vegaprotocol.io/protos/vega"
@@ -12,6 +13,7 @@ import (
 type OE interface {
 	events.Event
 	Order() *types.Order
+	VegaTime() time.Time
 }
 
 type OrderStore interface {


### PR DESCRIPTION
closes #705   In the datanode V1 market depth code we have this check -> https://github.com/vegaprotocol/data-node/blob/8c3a1e9845537c6d32dbdc01de4811cb30ee2fb4/subscribers/market_depth.go#L282  which relies on the vega time (block time) being correctly set, however as the V1 broker is multithreaded per event type there is no guarantee that the time event that sets the vega time will arrive at the market depth subscriber with the orders to which the time corresponds, so for example orders from block 1 and 2 could be processed with the time from block 2, resulting in orders from block 2 being thrown away due to the check above (v2 event broker is single threaded which is why it works in v2) .  This change fixes that by sending the vega time of the block along with the order event in the v1 broker to ensure that a correct sequence number is generated for each order event.