### PR TITLE
fix: metric missing parameter causes runtime error

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -526,7 +526,7 @@ func setupMetrics() error {
 		Gauge,
 		"active_subscriptions",
 		Namespace("datanode"),
-		Vectors("eventType"),
+		Vectors("apiType", "eventType"),
 		Help("Number of active subscriptions"),
 	); err != nil {
 		return err


### PR DESCRIPTION
closes #746 active subscription count metric has 2 label configure on the metric, was being invoked with one causing runtime error.