### PR TITLE
fix: allow node added to be updated when loading from a checkpoint

### DIFF
--- a/sqlstore/migrations/0001_initial.sql
+++ b/sqlstore/migrations/0001_initial.sql
@@ -529,7 +529,8 @@ CREATE TABLE IF NOT EXISTS nodes_announced (
   node_id               BYTEA NOT NULL,
   epoch_seq             BIGINT NOT NULL,
   added                 BOOLEAN NOT NULL,
-  PRIMARY KEY(node_id, epoch_seq)
+  vega_time             TIMESTAMP WITH TIME ZONE NOT NULL,
+  PRIMARY KEY(node_id, epoch_seq, vega_time)
 );
 
 CREATE TYPE validator_node_status as enum(

--- a/sqlstore/node.go
+++ b/sqlstore/node.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"code.vegaprotocol.io/data-node/entities"
 	"code.vegaprotocol.io/data-node/metrics"
@@ -77,20 +78,22 @@ func (store *Node) UpsertNode(ctx context.Context, node *entities.Node) error {
 }
 
 // AddNodeAnnoucedEvent store data about which epoch a particular node was added or removed from the roster of alidators
-func (store *Node) AddNodeAnnoucedEvent(ctx context.Context, nodeID entities.NodeID, aux *entities.ValidatorUpdateAux) error {
+func (store *Node) AddNodeAnnoucedEvent(ctx context.Context, nodeID entities.NodeID, vegatime time.Time, aux *entities.ValidatorUpdateAux) error {
 	defer metrics.StartSQLQuery("Node", "AddNodeAnnoucedEvent")()
 	_, err := store.pool.Exec(ctx, `
 		INSERT INTO nodes_announced (
 			node_id,
 			epoch_seq,
-			added)
+			added,
+		    vega_time)
 		VALUES
-			($1, $2, $3)
-		ON CONFLICT (node_id, epoch_seq) DO UPDATE SET
+			($1, $2, $3, $4)
+		ON CONFLICT (node_id, epoch_seq, vega_time) DO UPDATE SET
 			added=EXCLUDED.added`,
 		nodeID,
 		aux.FromEpoch,
 		aux.Added,
+		vegatime,
 	)
 
 	return err

--- a/sqlstore/node.go
+++ b/sqlstore/node.go
@@ -85,7 +85,9 @@ func (store *Node) AddNodeAnnoucedEvent(ctx context.Context, nodeID entities.Nod
 			epoch_seq,
 			added)
 		VALUES
-			($1, $2, $3)`,
+			($1, $2, $3)
+		ON CONFLICT (node_id, epoch_seq) DO UPDATE SET
+			added=EXCLUDED.added`,
 		nodeID,
 		aux.FromEpoch,
 		aux.Added,

--- a/sqlstore/node_test.go
+++ b/sqlstore/node_test.go
@@ -39,13 +39,13 @@ func addTestNode(t *testing.T, ps *sqlstore.Node, block entities.Block) entities
 	return node
 }
 
-func addNodeAnnounced(t *testing.T, ps *sqlstore.Node, nodeID entities.NodeID, added bool, fromEpoch uint64) {
+func addNodeAnnounced(t *testing.T, ps *sqlstore.Node, nodeID entities.NodeID, added bool, fromEpoch uint64, vegatime time.Time) {
 	t.Helper()
 	aux := entities.ValidatorUpdateAux{
 		Added:     added,
 		FromEpoch: fromEpoch,
 	}
-	err := ps.AddNodeAnnoucedEvent(context.Background(), nodeID, &aux)
+	err := ps.AddNodeAnnoucedEvent(context.Background(), nodeID, vegatime, &aux)
 	require.NoError(t, err)
 }
 
@@ -78,9 +78,10 @@ func TestGetNodes(t *testing.T) {
 	ns := sqlstore.NewNode(connectionSource)
 	block := addTestBlock(t, bs)
 
+	now := time.Now()
 	node1 := addTestNode(t, ns, block)
-	addNodeAnnounced(t, ns, node1.ID, true, 0)
-	addNodeAnnounced(t, ns, node1.ID, false, 7)
+	addNodeAnnounced(t, ns, node1.ID, true, 0, now)
+	addNodeAnnounced(t, ns, node1.ID, false, 7, now)
 	addRankingScore(t, ns, block, node1, 3)
 
 	// get all nodes
@@ -104,7 +105,7 @@ func TestGetNodes(t *testing.T) {
 
 	// check the value can be changed, since this happens during a checkpoint restore
 	// we were need to remove genesis validators if they aren't in the checkpoint
-	addNodeAnnounced(t, ns, node1.ID, true, 7)
+	addNodeAnnounced(t, ns, node1.ID, true, 7, now)
 	// get all nodes
 	found, err = ns.GetNodes(ctx, 7)
 	require.NoError(t, err)
@@ -124,13 +125,13 @@ func TestGetNodesJoiningAndLeaving(t *testing.T) {
 
 	// The node1 will exist int the epochs [2,3] and [6,7]
 	exists := map[int]bool{2: true, 3: true, 6: true, 7: true}
-	addNodeAnnounced(t, ns, node1.ID, true, 2)
-	addNodeAnnounced(t, ns, node1.ID, false, 4)
-	addNodeAnnounced(t, ns, node1.ID, true, 6)
-	addNodeAnnounced(t, ns, node1.ID, false, 8)
+	addNodeAnnounced(t, ns, node1.ID, true, 2, time.Now())
+	addNodeAnnounced(t, ns, node1.ID, false, 4, time.Now())
+	addNodeAnnounced(t, ns, node1.ID, true, 6, time.Now())
+	addNodeAnnounced(t, ns, node1.ID, false, 8, time.Now())
 
 	// node2 will always exist
-	addNodeAnnounced(t, ns, node2.ID, true, 0)
+	addNodeAnnounced(t, ns, node2.ID, true, 0, time.Now())
 
 	nodeID1 := node1.ID.String()
 	nodeID2 := node2.ID.String()
@@ -164,11 +165,11 @@ func TestGetNodeData(t *testing.T) {
 	addTestDelegation(t, ds, party1, node2, 4, block)
 
 	// The node1 will exist int the epochs [2,3]
-	addNodeAnnounced(t, ns, node1.ID, true, 2)
-	addNodeAnnounced(t, ns, node1.ID, false, 4)
+	addNodeAnnounced(t, ns, node1.ID, true, 2, time.Now())
+	addNodeAnnounced(t, ns, node1.ID, false, 4, time.Now())
 
 	// node2 will always exist
-	addNodeAnnounced(t, ns, node2.ID, true, 0)
+	addNodeAnnounced(t, ns, node2.ID, true, 0, time.Now())
 
 	// move to epoch 3 both nodes should exist
 	now := time.Unix(2000, 4)

--- a/sqlstore/node_test.go
+++ b/sqlstore/node_test.go
@@ -101,6 +101,14 @@ func TestGetNodes(t *testing.T) {
 
 	node, err = ns.GetNodeByID(ctx, "DEADBEEF", 3)
 	require.Error(t, err)
+
+	// check the value can be changed, since this happens during a checkpoint restore
+	// we were need to remove genesis validators if they aren't in the checkpoint
+	addNodeAnnounced(t, ns, node1.ID, true, 7)
+	// get all nodes
+	found, err = ns.GetNodes(ctx, 7)
+	require.NoError(t, err)
+	require.Len(t, found, 1)
 }
 
 func TestGetNodesJoiningAndLeaving(t *testing.T) {

--- a/sqlsubscribers/node.go
+++ b/sqlsubscribers/node.go
@@ -14,6 +14,7 @@ package sqlsubscribers
 
 import (
 	"context"
+	"time"
 
 	"code.vegaprotocol.io/data-node/entities"
 	"code.vegaprotocol.io/data-node/logging"
@@ -43,7 +44,7 @@ type NodeStore interface {
 	UpsertRanking(context.Context, *entities.RankingScore, *entities.RankingScoreAux) error
 	UpsertScore(context.Context, *entities.RewardScore, *entities.RewardScoreAux) error
 	UpdatePublicKey(context.Context, *entities.KeyRotation) error
-	AddNodeAnnoucedEvent(context.Context, entities.NodeID, *entities.ValidatorUpdateAux) error
+	AddNodeAnnoucedEvent(context.Context, entities.NodeID, time.Time, *entities.ValidatorUpdateAux) error
 }
 
 type Node struct {
@@ -87,7 +88,7 @@ func (n *Node) consumeUpdate(ctx context.Context, event ValidatorUpdateEvent) er
 	if err := errors.Wrap(n.store.UpsertNode(ctx, &node), "inserting node to SQL store failed"); err != nil {
 		return err
 	}
-	return errors.Wrap(n.store.AddNodeAnnoucedEvent(ctx, node.ID, &aux), "inserting node to SQL store failed")
+	return errors.Wrap(n.store.AddNodeAnnoucedEvent(ctx, node.ID, node.VegaTime, &aux), "inserting node to SQL store failed")
 }
 
 func (n *Node) consumeRankingScore(ctx context.Context, event ValidatorRankingScoreEvent) error {


### PR DESCRIPTION
When we restore from a checkpoint we send out `ValidatorUpdate` events that will clash with the ones that are sent based off the genesis file, and so the added field needs to be updated. For example if a node is in the genesis file, but not in the checkpoint we need to send out a follow up event to say "actually remove this guy".