### PR TITLE
feat: use debian image for data-node docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.14 as alpine
+FROM debian:bookworm-slim
 
-RUN apk add -U --no-cache ca-certificates
+RUN apt-get update -y \
+    && apt-get install -y ca-certificates libc6
 
-FROM scratch
-COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ADD bin/* /usr/local/bin/
+
 ENTRYPOINT ["/usr/local/bin/data-node"]


### PR DESCRIPTION
Required as embeded-postgres requires to link the `libc6` libraries and it makes no sense to copy it manually to scratch image