### PR TITLE
fix: Latest version of liquidity provision Should always be returned no matter the pagination order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [791](https://github.com/vegaprotocol/data-node/issues/791) - `v2` orders `api`
 
 ### 🐛 Fixes
+- [799](https://github.com/vegaprotocol/data-node/issues/799) - Latest versions of liquidity provision Should always be returned no matter the pagination order 
 - [](https://github.com/vegaprotocol/data-node/issues/xxx) -
 
 ## 0.53.0

--- a/sqlstore/liquidity_provision.go
+++ b/sqlstore/liquidity_provision.go
@@ -126,8 +126,7 @@ func (lp *LiquidityProvision) buildLiquidityProvisionsSelect(partyID entities.Pa
 	reference string) (string, []interface{}) {
 	var bindVars []interface{}
 
-	selectSql := fmt.Sprintf(`select distinct on (id) %s
-from liquidity_provisions`, sqlOracleLiquidityProvisionColumns)
+	selectSql := fmt.Sprintf(`select %s from liquidity_provisions_current`, sqlOracleLiquidityProvisionColumns)
 
 	where := ""
 

--- a/sqlstore/migrations/0001_initial.sql
+++ b/sqlstore/migrations/0001_initial.sql
@@ -911,6 +911,8 @@ create table if not exists liquidity_provisions (
 
 select create_hypertable('liquidity_provisions', 'vega_time', chunk_time_interval => INTERVAL '1 day');
 
+CREATE VIEW liquidity_provisions_current AS ( SELECT DISTINCT ON (id) * FROM liquidity_provisions ORDER BY id DESC, vega_time DESC);
+
 CREATE TYPE transfer_type AS enum('OneOff','Recurring','Unknown');
 CREATE TYPE transfer_status AS enum('STATUS_UNSPECIFIED','STATUS_PENDING','STATUS_DONE','STATUS_REJECTED','STATUS_STOPPED','STATUS_CANCELLED');
 


### PR DESCRIPTION
closes #799 